### PR TITLE
docs: add Thanos OSS contribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 <!-- OSS_CONTRIBUTIONS_START -->
 | Project | Contribution | PR | Merged |
 | --- | --- | --- | --- |
+| [Thanos](https://github.com/thanos-io/thanos) | Improved query-frontend range-query caching by reusing compatible lower-step cache entries with step-aware subsampling and bulk fallback cache fetches. | [#8876](https://github.com/thanos-io/thanos/pull/8876) | 2026-07-01 |
 | [Uptime Kuma](https://github.com/louislam/uptime-kuma) | Resolved Steam monitor hostnames before Steam API `addr` filtering and added backend tests. | [#7542](https://github.com/louislam/uptime-kuma/pull/7542) | 2026-06-25 |
 <!-- OSS_CONTRIBUTIONS_END -->
 


### PR DESCRIPTION
## Summary
- Add Thanos PR #8876 to the open source contributions table.

## Verification
- Inspected README diff for the one-line table addition.
- Repository has no .github/workflows directory, so no local workflow-specific check is available before PR creation.